### PR TITLE
Add ASP.NET Core Vite TagHelpers

### DIFF
--- a/examples/ViteNET.BlazorServer/Pages/_Layout.cshtml
+++ b/examples/ViteNET.BlazorServer/Pages/_Layout.cshtml
@@ -3,6 +3,7 @@
 @inject IViteManifest Manifest
 @namespace ViteNET.BlazorServer.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, Vite.AspNetCore
 
 <!DOCTYPE html>
 <html lang="en">
@@ -12,7 +13,7 @@
 	<link rel="icon" type="image/svg+xml" href="/vite.svg" />
 	<base href="~/" />
 	<environment include="Production">
-		<link rel="stylesheet" href="~/@Manifest["main.css"]!.File" asp-append-version="true" />
+		<link rel="stylesheet" vite-manifest="main.css" asp-append-version="true" />
 	</environment>
 	<component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
 </head>
@@ -36,7 +37,7 @@
 
 	<environment include="Development">
 		<!-- Vite development server script -->
-		<script type="module" src="@@vite/client"></script>
+		<vite-client/>
 		<script type="module" src="main.ts"></script>
 	</environment>
 	@*<environment include="Production">

--- a/examples/ViteNET.BlazorServer/Pages/_Layout.cshtml
+++ b/examples/ViteNET.BlazorServer/Pages/_Layout.cshtml
@@ -1,6 +1,4 @@
 ﻿@using Microsoft.AspNetCore.Components.Web
-@using Vite.AspNetCore.Abstractions;
-@inject IViteManifest Manifest
 @namespace ViteNET.BlazorServer.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
 @addTagHelper *, Vite.AspNetCore
@@ -13,7 +11,7 @@
 	<link rel="icon" type="image/svg+xml" href="/vite.svg" />
 	<base href="~/" />
 	<environment include="Production">
-		<link rel="stylesheet" vite-manifest="main.css" asp-append-version="true" />
+		<link rel="stylesheet" vite-href="main.css" asp-append-version="true" />
 	</environment>
 	<component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
 </head>
@@ -38,7 +36,7 @@
 	<environment include="Development">
 		<!-- Vite development server script -->
 		<vite-client/>
-		<script type="module" src="main.ts"></script>
+		<script type="module" vite-src="main.ts"></script>
 	</environment>
 	@*<environment include="Production">
 		<script type="module" src="@Manifest["main.ts"]!.File" asp-append-version="true"></script>

--- a/examples/ViteNET.MVC/Views/Shared/_Layout.cshtml
+++ b/examples/ViteNET.MVC/Views/Shared/_Layout.cshtml
@@ -1,7 +1,4 @@
-﻿@* The manifest can only be accessed after building the assets with 'npm run build'. *@
-@inject IViteManifest Manifest
-
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 <head>
 	<meta charset="UTF-8" />
@@ -9,7 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>@ViewData["Title"]</title>
 	<environment include="Production">
-		<link rel="stylesheet" href="~/@Manifest["main.css"]!.File" asp-append-version="true" />
+		<link rel="stylesheet" vite-manifest="main.css" asp-append-version="true" />	
 	</environment>
 </head>
 <body>
@@ -19,11 +16,11 @@
 
 	<environment include="Development">
 		<!-- Vite development server script -->
-		<script type="module" src="~/@@vite/client"></script>
+		<vite-client />
 		<script type="module" src="~/main.ts"></script>
 	</environment>
 	<environment include="Production">
-		<script type="module" src="~/@Manifest["main.ts"]!.File" asp-append-version="true"></script>
+		<script type="module" vite-manifest="main.ts" asp-append-version="true"></script>
 	</environment>
 
 	@await RenderSectionAsync("Scripts", required: false)

--- a/examples/ViteNET.MVC/Views/Shared/_Layout.cshtml
+++ b/examples/ViteNET.MVC/Views/Shared/_Layout.cshtml
@@ -6,7 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>@ViewData["Title"]</title>
 	<environment include="Production">
-		<link rel="stylesheet" vite-manifest="main.css" asp-append-version="true" />	
+		<link rel="stylesheet" vite-href="main.css" asp-append-version="true" />	
 	</environment>
 </head>
 <body>
@@ -20,7 +20,7 @@
 		<script type="module" src="~/main.ts"></script>
 	</environment>
 	<environment include="Production">
-		<script type="module" vite-manifest="main.ts" asp-append-version="true"></script>
+		<script type="module" vite-src="main.ts" asp-append-version="true"></script>
 	</environment>
 
 	@await RenderSectionAsync("Scripts", required: false)

--- a/examples/ViteNET.MVC/Views/_ViewImports.cshtml
+++ b/examples/ViteNET.MVC/Views/_ViewImports.cshtml
@@ -4,3 +4,4 @@
 @using Vite.AspNetCore.Abstractions
 @using Vite.AspNetCore.Services
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, Vite.AspNetCore

--- a/examples/ViteNET.RazorPages/Pages/Shared/_Layout.cshtml
+++ b/examples/ViteNET.RazorPages/Pages/Shared/_Layout.cshtml
@@ -1,7 +1,4 @@
-﻿@* The manifest can only be accessed after building the assets with 'npm run build'. *@
-@inject IViteManifest Manifest
-
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 <head>
 	<meta charset="UTF-8" />
@@ -9,7 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>@ViewData["Title"]</title>
 	<environment include="Production">
-		<link rel="stylesheet" href="~/@Manifest["main.css"]!.File" asp-append-version="true" />
+		<link rel="stylesheet" vite-manifest="main.css" asp-append-version="true" />
 	</environment>
 </head>
 <body>
@@ -19,11 +16,11 @@
 
 	<environment include="Development">
 		<!-- Vite development server script -->
-		<script type="module" src="~/@@vite/client"></script>
+		<vite-client/>
 		<script type="module" src="~/main.ts"></script>
 	</environment>
 	<environment include="Production">
-		<script type="module" src="~/@Manifest["main.ts"]!.File" asp-append-version="true"></script>
+		<script type="module" vite-manifest="main.ts" asp-append-version="true"></script>
 	</environment>
 
 	@await RenderSectionAsync("Scripts", required: false)

--- a/examples/ViteNET.RazorPages/Pages/Shared/_Layout.cshtml
+++ b/examples/ViteNET.RazorPages/Pages/Shared/_Layout.cshtml
@@ -6,7 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 	<title>@ViewData["Title"]</title>
 	<environment include="Production">
-		<link rel="stylesheet" vite-manifest="main.css" asp-append-version="true" />
+		<link rel="stylesheet" vite-href="main.css" asp-append-version="true" />
 	</environment>
 </head>
 <body>
@@ -20,7 +20,7 @@
 		<script type="module" src="~/main.ts"></script>
 	</environment>
 	<environment include="Production">
-		<script type="module" vite-manifest="main.ts" asp-append-version="true"></script>
+		<script type="module" vite-src="main.ts" asp-append-version="true"></script>
 	</environment>
 
 	@await RenderSectionAsync("Scripts", required: false)

--- a/examples/ViteNET.RazorPages/Pages/_ViewImports.cshtml
+++ b/examples/ViteNET.RazorPages/Pages/_ViewImports.cshtml
@@ -4,3 +4,4 @@
 @using Vite.AspNetCore.Services
 @namespace ViteNET.RazorPages.Pages
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@addTagHelper *, Vite.AspNetCore

--- a/src/Vite.AspNetCore/README.md
+++ b/src/Vite.AspNetCore/README.md
@@ -90,6 +90,27 @@ By using the Vite Manifest service, you can access the manifest in your applicat
 </environment>
 ```
 
+You can also access the Vite manifest by using the tag helpers included in the package. Be sure to add the following in your `_ViewImports.cshtml`
+
+```
+@addTagHelper *, Vite.AspNetCore
+```
+
+Followed by using the `vite-manifest` attribute on `<script>` and `link` tags.
+
+```HTML
+<link rel="stylesheet" vite-manifest="main.css" asp-append-version="true" />
+<script type="module" vite-manifest="main.ts" asp-append-version="true"></script>
+```
+
+You even has access to a `vite-client` tag, which outputs the necessary client script tag.
+
+```html
+<vite-client />
+<!-- Is equivalent to -->
+<script type="module" src="~/@@vite/client"></script>
+```
+
 Enable the service by adding these lines to your `Program.cs` or `Startup` class. 👍
 
 ```CSharp

--- a/src/Vite.AspNetCore/TagHelpers/ViteClientTagHelper.cs
+++ b/src/Vite.AspNetCore/TagHelpers/ViteClientTagHelper.cs
@@ -19,10 +19,10 @@ public class ViteClientTagHelper : TagHelper
 
         // merge attributes
         foreach (var attribute in context.AllAttributes) {
-            output.Attributes.Add(attribute);
+            output.Attributes.SetAttribute(attribute);
         }
 
-        output.Attributes.Add("type", "module");
-        output.Attributes.Add("src", "~/@vite/client");
+        output.Attributes.SetAttribute("type", "module");
+        output.Attributes.SetAttribute("src", "~/@vite/client");
     }
 }

--- a/src/Vite.AspNetCore/TagHelpers/ViteClientTagHelper.cs
+++ b/src/Vite.AspNetCore/TagHelpers/ViteClientTagHelper.cs
@@ -1,0 +1,28 @@
+// Copyright (c) 2023 Quetzal Rivera.
+// Licensed under the MIT License, See LICENCE in the project root for license information.
+
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Vite.AspNetCore.TagHelpers;
+
+/// <summary>
+/// The &lt;vite-client /&gt; generates a script tag pointing to ~/@vite/client
+/// </summary>
+[HtmlTargetElement(ViteClientTagName, TagStructure = TagStructure.NormalOrSelfClosing)]
+public class ViteClientTagHelper : TagHelper
+{
+    private const string ViteClientTagName = "vite-client";
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        output.Reinitialize("script", TagMode.StartTagAndEndTag);
+
+        // merge attributes
+        foreach (var attribute in context.AllAttributes) {
+            output.Attributes.Add(attribute);
+        }
+
+        output.Attributes.Add("type", "module");
+        output.Attributes.Add("src", "~/@vite/client");
+    }
+}

--- a/src/Vite.AspNetCore/TagHelpers/ViteManifestTagHelper.cs
+++ b/src/Vite.AspNetCore/TagHelpers/ViteManifestTagHelper.cs
@@ -1,0 +1,76 @@
+// Copyright (c) 2023 Quetzal Rivera.
+// Licensed under the MIT License, See LICENCE in the project root for license information.
+
+using Microsoft.AspNetCore.Mvc.Razor.TagHelpers;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.Extensions.Logging;
+using Vite.AspNetCore.Abstractions;
+
+namespace Vite.AspNetCore.TagHelpers;
+
+/// <summary>
+/// Use the vite-manifest attribute on link or script tags to
+/// find the matching file from the vite-generated "assets.manifest.json" file
+/// </summary>
+[HtmlTargetElement("script", Attributes = ViteManifestAttribute)]
+[HtmlTargetElement("link", Attributes = ViteManifestAttribute)]
+public class ViteManifestTagHelper : TagHelper
+{
+    private readonly IViteManifest _manifest;
+    private readonly ILogger<ViteManifestTagHelper> _logger;
+    private const string ViteManifestAttribute = "vite-manifest";
+
+    public ViteManifestTagHelper(IViteManifest manifest, ILogger<ViteManifestTagHelper> logger)
+    {
+        this._manifest = manifest;
+        this._logger = logger;
+    }
+
+    /// <summary>
+    /// The key of the entry in "assets.manifest.json"
+    /// The manifest can only be accessed after building the assets with 'npm run build'.
+    /// </summary>
+    [HtmlAttributeName(ViteManifestAttribute)]
+    public string? Key { get; set; }
+
+    [ViewContext] [HtmlAttributeNotBound] public ViewContext ViewContext { get; set; } = default!;
+
+    public override int Order => int.MinValue;
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        if (string.IsNullOrWhiteSpace(this.Key))
+        {
+            this._logger.LogWarning("vite-manifest value missing on {View}", ViewContext.View.Path);
+            return;
+        }
+
+        var file = this._manifest[this.Key]?.File;
+
+        if (string.IsNullOrEmpty(file))
+        {
+            this._logger.LogWarning("\"{Key}\" was not found in Vite manifest (check {View})", this.Key,
+                ViewContext.View.Path);
+            return;
+        }
+
+        // remove the attribute from the output
+        output.Attributes.RemoveAll("vite-manifest");
+
+        var attribute = output.TagName switch
+        {
+            "script" => "src",
+            "link" => "href",
+            _ => throw new ArgumentOutOfRangeException(nameof(output.TagName), output.TagName)
+        };
+
+        output.Attributes.Add(new TagHelperAttribute(
+            attribute,
+            $"~/{file}",
+            HtmlAttributeValueStyle.DoubleQuotes)
+        );
+    }
+}

--- a/src/Vite.AspNetCore/TagHelpers/ViteManifestTagHelper.cs
+++ b/src/Vite.AspNetCore/TagHelpers/ViteManifestTagHelper.cs
@@ -57,7 +57,7 @@ public class ViteManifestTagHelper : TagHelper
         {
             "script" => (attribute: "src", value: Src ?? string.Empty),
             "link" => (attribute: "href", value: Href ?? string.Empty),
-            _ => throw new ArgumentOutOfRangeException(nameof(output.TagName), output.TagName)
+            _ => (attribute: string.Empty, value : string.Empty)
         };
         
         // always attempt to remove the vite attribute from the output

--- a/src/Vite.AspNetCore/TagHelpers/ViteManifestTagHelper.cs
+++ b/src/Vite.AspNetCore/TagHelpers/ViteManifestTagHelper.cs
@@ -67,7 +67,7 @@ public class ViteManifestTagHelper : TagHelper
             _ => throw new ArgumentOutOfRangeException(nameof(output.TagName), output.TagName)
         };
 
-        output.Attributes.Add(new TagHelperAttribute(
+        output.Attributes.SetAttribute(new TagHelperAttribute(
             attribute,
             $"~/{file}",
             HtmlAttributeValueStyle.DoubleQuotes)

--- a/src/Vite.AspNetCore/TagHelpers/ViteManifestTagHelper.cs
+++ b/src/Vite.AspNetCore/TagHelpers/ViteManifestTagHelper.cs
@@ -53,7 +53,8 @@ public class ViteManifestTagHelper : TagHelper
 
     public override void Process(TagHelperContext context, TagHelperOutput output)
     {
-        var tag = output.TagName switch
+        // because some people might shout their tag names like SCRIPT and LINK!
+        var tag = output.TagName.ToLowerInvariant() switch
         {
             "script" => (attribute: "src", value: Src ?? string.Empty),
             "link" => (attribute: "href", value: Href ?? string.Empty),


### PR DESCRIPTION
This reduces some of the boilerplate that can be associated with injecting the manifest into layout pages.

I added two tag helpers: ViteClientTagHelper and ViteManifestTagHelper.

See samples for usage of each.