### PR TITLE
ViteDevMiddleware will wait for server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+.idea
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/src/Vite.AspNetCore/README.md
+++ b/src/Vite.AspNetCore/README.md
@@ -120,14 +120,16 @@ By default, the manifest name is `manifest.json` and it's expected to be in the 
 
 You can change the configuration for the middleware by overriding the following properties. ⚙️
 
-| Property                 | Description                                                                                            |
-| ------------------------ | ------------------------------------------------------------------------------------------------------ |
-| `Vite:PackageManager`    | The name of the package manager to use. Default value is `npm`.                                        |
-| `Vite:WorkingDirectory`  | The working directory where your package.json file is located. Default value is the content root path. |
-| `Vite:Server:AutoRun`    | Enable or disable the automatic start of the Vite Dev Server. Default value is `true`.                 |
-| `Vite:Server:Port`       | The port where the Vite Dev Server will be running. Default value is `5173`.                           |
-| `Vite:Server:UseHttps`   | If true, the middleware will use HTTPS to connect to the Vite Dev Server. Default value is `false`.    |
-| `Vite:Server:ScriptName` | The script name to run the Vite Dev Server. Default value is `dev`.                                    |
+| Property                       | Description                                                                                            |
+|--------------------------------|--------------------------------------------------------------------------------------------------------|
+| `Vite:PackageManager`          | The name of the package manager to use. Default value is `npm`.                                        |
+| `Vite:WorkingDirectory`        | The working directory where your package.json file is located. Default value is the content root path. |
+| `Vite:Server:AutoRun`          | Enable or disable the automatic start of the Vite Dev Server. Default value is `true`.                 |
+| `Vite:Server:Port`             | The port where the Vite Dev Server will be running. Default value is `5173`.                           |
+| `Vite:Server:UseHttps`         | If true, the middleware will use HTTPS to connect to the Vite Dev Server. Default value is `false`.    |
+| `Vite:Server:ScriptName`       | The script name to run the Vite Dev Server. Default value is `dev`.                                    |
+| `Vite:Server:TimeOutInSeconds` | The timeout in seconds spent waiting for the vite dev server (between 0 and 60). Default is `3`        |
+
 
 See the following example.
 

--- a/src/Vite.AspNetCore/Services/NodeScriptRunner.cs
+++ b/src/Vite.AspNetCore/Services/NodeScriptRunner.cs
@@ -21,7 +21,7 @@ namespace Vite.AspNetCore.Services
 		/// <summary>
 		/// Initializes a new instance of the <see cref="NodeScriptRunner"/> class.
 		/// </summary>
-		public NodeScriptRunner(ILogger logger, string pkgManagerCommand, string scriptName, string workingDirectory, CancellationToken cancellationToken = default)
+		public NodeScriptRunner(ILogger logger, string pkgManagerCommand, string scriptName, string workingDirectory, Action<string>? onStandardOutputRead = null, CancellationToken cancellationToken = default)
 		{
 			_logger = logger;
 			// If the package manager command is null or empty, throw an exception.
@@ -80,8 +80,8 @@ namespace Vite.AspNetCore.Services
 			}
 
 			// Create the stream readers.
-			this._stdOutReader = new NodeStreamReader(logger, this._npmProcess.StandardOutput, cancellationToken);
-			this._stdErrorReader = new NodeStreamReader(logger, this._npmProcess.StandardError, cancellationToken);
+			this._stdOutReader = new NodeStreamReader(logger, this._npmProcess.StandardOutput, onStandardOutputRead, cancellationToken);
+            this._stdErrorReader = new NodeStreamReader(logger, this._npmProcess.StandardError, cancellationToken: cancellationToken);
 
 			cancellationToken.Register(((IDisposable)this).Dispose);
 		}

--- a/src/Vite.AspNetCore/Services/ViteDevMiddleware.cs
+++ b/src/Vite.AspNetCore/Services/ViteDevMiddleware.cs
@@ -8,117 +8,139 @@ using Microsoft.Extensions.Logging;
 
 namespace Vite.AspNetCore.Services
 {
-	/// <summary>
-	/// Represents a middleware that proxies requests to the Vite Dev Server.
-	/// </summary>
-	public class ViteDevMiddleware : IMiddleware, IDisposable
-	{
-		private readonly ILogger<ViteDevMiddleware> _logger;
-		private readonly string _viteServerBaseUrl;
-		private readonly NodeScriptRunner? _scriptRunner;
+    /// <summary>
+    /// Represents a middleware that proxies requests to the Vite Dev Server.
+    /// </summary>
+    public class ViteDevMiddleware : IMiddleware, IDisposable
+    {
+        private readonly ILogger<ViteDevMiddleware> _logger;
+        private readonly string _viteServerBaseUrl;
+        private readonly NodeScriptRunner? _scriptRunner;
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="ViteDevMiddleware"/> class.
-		/// </summary>
-		/// <param name="logger">The <see cref="ILogger{ViteDevMiddleware}"/> instance.</param>
-		/// <param name="configuration">The <see cref="IConfiguration"/> instance.</param>
-		/// <param name="environment">The <see cref="IWebHostEnvironment"/> instance.</param>
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ViteDevMiddleware"/> class.
+        /// </summary>
+        /// <param name="logger">The <see cref="ILogger{ViteDevMiddleware}"/> instance.</param>
+        /// <param name="configuration">The <see cref="IConfiguration"/> instance.</param>
+        /// <param name="environment">The <see cref="IWebHostEnvironment"/> instance.</param>
 		public ViteDevMiddleware(ILogger<ViteDevMiddleware> logger, IConfiguration configuration, IWebHostEnvironment environment)
-		{
-			// Set the logger.
-			this._logger = logger;
-			// Read the Vite options from the configuration.
-			var viteOptions = configuration.GetSection(ViteOptions.Vite).Get<ViteOptions>();
-			// Get the port from the configuration.
-			var port = viteOptions.Server.Port;
-			// Check if https is enabled.
-			var https = viteOptions.Server.Https;
-			// Build the base url.
-			this._viteServerBaseUrl = $"{(https ? "https" : "http")}://localhost:{port}";
+        {
+            // Set the logger.
+            this._logger = logger;
+            // Read the Vite options from the configuration.
+            var viteOptions = configuration.GetSection(ViteOptions.Vite).Get<ViteOptions>();
+            // Get the port from the configuration.
+            var port = viteOptions.Server.Port;
+            // Check if https is enabled.
+            var https = viteOptions.Server.Https;
+            // Build the base url.
+            this._viteServerBaseUrl = $"{(https ? "https" : "http")}://localhost:{port}";
 
-			// Prepare and run the Vite Dev Server if AutoRun is true.
-			if (viteOptions.Server.AutoRun)
-			{
-				// Gets the package manager command.
-				var pkgManagerCommand = viteOptions.PackageManager;
-				// Gets the working directory.
-				var workingDirectory = viteOptions.WorkingDirectory ?? environment.ContentRootPath;
-				// Gets the script name.= to run the Vite Dev Server.
-				var scriptName = viteOptions.Server.ScriptName;
-				// Create a new instance of the NodeScriptRunner class.
-				this._scriptRunner = new NodeScriptRunner(logger, pkgManagerCommand, scriptName, workingDirectory);
-				logger.LogInformation("The middleware has called the dev script. It may take a few seconds before the Vite Dev Server becomes available.");
-			}
-		}
+            // Prepare and run the Vite Dev Server if AutoRun is true.
+            if (viteOptions.Server.AutoRun)
+            {
+                // Gets the package manager command.
+                var pkgManagerCommand = viteOptions.PackageManager;
+                // Gets the working directory.
+                var workingDirectory = viteOptions.WorkingDirectory ?? environment.ContentRootPath;
+                // Gets the script name.= to run the Vite Dev Server.
+                var scriptName = viteOptions.Server.ScriptName;
+                // Create a new instance of the NodeScriptRunner class.
+                var waiting = new TimeSpan(0);
+                this._scriptRunner = new NodeScriptRunner(logger, pkgManagerCommand, scriptName, workingDirectory,
+                    line =>
+                    {
+                        if (!line.Contains(this._viteServerBaseUrl))
+                        {
+                            return;
+                        }
+                        logger.LogInformation("Found Vite Server: {ViteServerBaseUrl}.", this._viteServerBaseUrl);
+                        waiting = TimeSpan.MaxValue;
+                    });
 
-		/// <inheritdoc />
-		public async Task InvokeAsync(HttpContext context, RequestDelegate next)
-		{
-			// If the request path is not null, process.
-			if (context.Request.Path.HasValue)
-			{
-				// Get the request path
-				var path = context.Request.Path.Value;
-				// Proxy the request to the Vite Dev Server.
-				await ProxyAsync(context, next, path);
-			}
-			// If the request path is null, call the next middleware.
-			else
-			{
-				await next(context);
-			}
-		}
+                logger.LogInformation(
+                    "The middleware has called the dev script. It may take a few seconds before the Vite Dev Server becomes available.");
 
-		/// <summary>
-		/// Proxies the request to the Vite Dev Server.
-		/// </summary>
-		/// <param name="context">The <see cref="HttpContext"/> instance.</param>
-		/// <param name="path">The request path.</param>
-		/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-		private async Task ProxyAsync(HttpContext context, RequestDelegate next, string path)
-		{
-			using HttpClient client = new() { BaseAddress = new Uri(this._viteServerBaseUrl) };
+                // wait for the server to start, based on seconds from options
+                // the default value is 3 seconds
+                // limit to between 0 and 60 seconds (don't hang forever)
+                var timeout = TimeSpan.FromSeconds(Math.Clamp(viteOptions.Server.TimeoutInSeconds, 0, 60));
+                var increment = TimeSpan.FromMilliseconds(250);
+                while (waiting < timeout) {
+                    waiting = waiting.Add(increment);
+                    Thread.Sleep(increment);
+                }
+            }
+        }
 
-			try
-			{
-				// Get the requested path from the Vite Dev Server.
-				var response = await client.GetAsync(path);
-				// If the response is successful, process.
-				if (response.IsSuccessStatusCode)
-				{
-					// Get the response content.
-					var content = await response.Content.ReadAsByteArrayAsync();
-					// Get the response content type.
-					var contentType = response.Content.Headers.ContentType?.MediaType;
-					// Set the response content type.
-					context.Response.ContentType = contentType ?? "application/octet-stream";
-					// Set the response content length.
-					context.Response.ContentLength = content.Length;
-					// Write the response content.
-					await context.Response.Body.WriteAsync(content);
-				}
-				// Otherwise, call the next middleware.
-				else
-				{
-					await next(context);
-				}
-			}
-			catch (HttpRequestException exp)
-			{
-				// Log the exception.
-				this._logger.LogWarning("{Message}. Make sure Vite Dev Server is running.", exp.Message);
-				await next(context);
-			}
-		}
+        /// <inheritdoc />
+        public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+        {
+            // If the request path is not null, process.
+            if (context.Request.Path.HasValue)
+            {
+                // Get the request path
+                var path = context.Request.Path.Value;
+                // Proxy the request to the Vite Dev Server.
+                await ProxyAsync(context, next, path);
+            }
+            // If the request path is null, call the next middleware.
+            else
+            {
+                await next(context);
+            }
+        }
 
-		void IDisposable.Dispose()
-		{
-			// If the script runner was defined, dipose it.
-			if (this._scriptRunner != null)
-			{
-				((IDisposable)this._scriptRunner).Dispose();
-			}
-			GC.SuppressFinalize(this);
-		}
-	}
+        /// <summary>
+        /// Proxies the request to the Vite Dev Server.
+        /// </summary>
+        /// <param name="context">The <see cref="HttpContext"/> instance.</param>
+        /// <param name="path">The request path.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        private async Task ProxyAsync(HttpContext context, RequestDelegate next, string path)
+        {
+            using HttpClient client = new() { BaseAddress = new Uri(this._viteServerBaseUrl) };
+
+            try
+            {
+                // Get the requested path from the Vite Dev Server.
+                var response = await client.GetAsync(path);
+                // If the response is successful, process.
+                if (response.IsSuccessStatusCode)
+                {
+                    // Get the response content.
+                    var content = await response.Content.ReadAsByteArrayAsync();
+                    // Get the response content type.
+                    var contentType = response.Content.Headers.ContentType?.MediaType;
+                    // Set the response content type.
+                    context.Response.ContentType = contentType ?? "application/octet-stream";
+                    // Set the response content length.
+                    context.Response.ContentLength = content.Length;
+                    // Write the response content.
+                    await context.Response.Body.WriteAsync(content);
+                }
+                // Otherwise, call the next middleware.
+                else
+                {
+                    await next(context);
+                }
+            }
+            catch (HttpRequestException exp)
+            {
+                // Log the exception.
+                this._logger.LogWarning("{Message}. Make sure Vite Dev Server is running.", exp.Message);
+                await next(context);
+            }
+        }
+
+        void IDisposable.Dispose()
+        {
+            // If the script runner was defined, dispose it.
+            if (this._scriptRunner != null)
+            {
+                ((IDisposable)this._scriptRunner).Dispose();
+            }
+            GC.SuppressFinalize(this);
+        }
+    }
 }

--- a/src/Vite.AspNetCore/Utilities/NodeStreamReader.cs
+++ b/src/Vite.AspNetCore/Utilities/NodeStreamReader.cs
@@ -15,6 +15,7 @@ namespace Vite.AspNetCore.Utilities
 		private readonly ILogger _logger;
 		private readonly StreamReader _streamReader;
 		private readonly StringBuilder _linesBuffer;
+        private readonly Action<string>? _onOutputBufferRead;
 
 		/// <summary>
 		/// Initialize a new instance of the <see cref="NodeStreamReader"/> class.
@@ -23,7 +24,7 @@ namespace Vite.AspNetCore.Utilities
 		/// <param name="streamReader">The stream reader.</param>
 		/// <param name="cancellationToken">The cancellation token.</param>
 		/// <exception cref="ArgumentNullException"></exception>
-		public NodeStreamReader(ILogger logger, StreamReader streamReader, CancellationToken cancellationToken = default)
+		public NodeStreamReader(ILogger logger, StreamReader streamReader, Action<string>? onOutputBufferRead = null, CancellationToken cancellationToken = default)
 		{
 			// Save the logger.
 			_logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -31,6 +32,8 @@ namespace Vite.AspNetCore.Utilities
 			_streamReader = streamReader ?? throw new ArgumentNullException(nameof(streamReader));
 			// Initialize the lines buffer.
 			_linesBuffer = new StringBuilder();
+            // output buffer reader
+            _onOutputBufferRead = onOutputBufferRead;
 			Task.Factory.StartNew(Run, cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
 		}
 
@@ -82,7 +85,8 @@ namespace Vite.AspNetCore.Utilities
 			if (!string.IsNullOrEmpty(line) && !string.IsNullOrWhiteSpace(line) && !line.StartsWith('>'))
 			{
 				this._logger.LogInformation("{Line}", line);
-			}
+                this._onOutputBufferRead?.Invoke(line);
+            }
 		}
 	}
 }

--- a/src/Vite.AspNetCore/ViteServerOptions.cs
+++ b/src/Vite.AspNetCore/ViteServerOptions.cs
@@ -25,5 +25,9 @@ namespace Vite.AspNetCore
 		/// The script name to run the Vite Dev Server. Default value is "dev".
 		/// </summary>
 		public string ScriptName { get; set; } = "dev";
+        /// <summary>
+        /// Wait for Vite Server to load in seconds. Default value is "3".
+        /// </summary>
+        public int TimeoutInSeconds { get; set; } = 3;
 	}
 }


### PR DESCRIPTION
Added some code to watch the standard output for
the dev server's url, which let's us know the server is up and ready.

This opens the web page when the websocket server is ready to start receiving clients, thus avoiding having to refresh the first time the page loads.